### PR TITLE
timeout if the exposed port is inaccessible

### DIFF
--- a/wait
+++ b/wait
@@ -5,12 +5,23 @@ set -e
 host=$(env | grep _TCP_ADDR | head -1 | cut -d = -f 2)
 port=$(env | grep _TCP_PORT | head -1 | cut -d = -f 2)
 
-echo -n "waiting for TCP connection to $host:$port..."
+# assuming a timeout of 30 second should be enough for a container ?
+TIMEOUT=30
 
+echo -n "waiting for TCP connection to $host:$port ..."
+COUNTER=0
 while ! nc -w 1 $host $port 2>/dev/null
 do
-  echo -n .
-  sleep 1
+    if [[ $COUNTER -lt $TIMEOUT ]]; then
+        echo -n .
+        sleep 1
+        COUNTER=$((COUNTER+1))
+    else
+        echo "No TCP connection received on $host:$port "
+        break
+    fi
 done
 
-echo 'ok'
+if [[ $COUNTER -lt $TIMEOUT ]]; then
+    echo " OK"
+fi


### PR DESCRIPTION
Preface: 
docker-wait did not timeout, if for some reason the container did not listen on the exposed port that it listens to see if there are any connection attempts. 

Assumptions:
i) The ports that the app container exposes should be active and listen for traffic.
ii) docker-wait should be independent of whether or not there is a problem with the app/plugin container build.

Ref: [Issue #30 (Waiting for container to be ready)](https://github.com/dokku/dokku-rabbitmq/issues/30)

TBD: 

Timeout : Perhaps we could introduce an optional env_var, say BUILD_TIMEOUT on the plugin containers, that the plugin developers could use/set so as to continue with heavier builds that exceeds 30 seconds ?